### PR TITLE
(2/3) Develop swc layers integration

### DIFF
--- a/src/pyfao56/model.py
+++ b/src/pyfao56/model.py
@@ -329,10 +329,6 @@ class Model:
                     (io.Kcbmid-io.Kcbini),0.001,io.h])
         if io.updh > 0: io.h = io.updh
 
-        # Root depth (Zr, m) - FAO-56 page 279
-        io.Zr = max([io.Zrini + (io.Zrmax-io.Zrini)*(io.Kcb-
-                                                     io.Kcbini)/
-                 (io.Kcbmid-io.Kcbini),0.001,io.Zr])
         #Root depth (Zr, m) - FAO-56 page 279
         io.Zr = max([io.Zrini + (io.Zrmax-io.Zrini)*(io.Kcb-io.Kcbini)/
                      (io.Kcbmid-io.Kcbini),0.001,io.Zr])


### PR DESCRIPTION
Added switches to the model class that will use the soil profile dictionary from the SoilWater class provided that the dictionary is not empty. These switches should allow users to calculate SWD as the root zone passes through different soil layers. So, instead of calculating SWD for the entire "bucket" of soil (as the FAO-56 methodology explicitly does), users can now calculate SWD for the soil that the projected root zone actually passes through (given the time of the season and assumed soil layers). 