### PR TITLE
Removed SWD Dataframe

### DIFF
--- a/src/pyfao56/tools/soil_water.py
+++ b/src/pyfao56/tools/soil_water.py
@@ -1,3 +1,8 @@
+#ToDo: replace model I/O with par and sol
+# add root simulation calculations to rzsw function
+# Make a new method for computing measured Ks
+# rework all docstrings
+
 """
 ########################################################################
 The soil_water.py module contains the SoilWater class, which provides
@@ -27,14 +32,11 @@ class SoilWater:
         Volumetric soil water content (cm^3/cm^3) data as float
         index   - Bottom depth of soil profile layer as integer (cm)
         columns - measurement date in string 'YYYY-DOY' format
-    swddata : DataFrame
-        Fractional soil water deficit data as float
-        index   - Bottom depth of soil profile layer as integer (cm)
-        columns - string measurement date in 'YYYY-DOY' format
     rzdata : DataFrame
         Soil water deficit (mm) data as float
         index   - string measurement date in 'YYYY-DOY' format
-        columns - ['Year', 'DOY', 'Zr', 'SWDr', 'SWDrmax']
+        columns - ['Year', 'DOY', 'Zr', 'SWDr', 'SWDrmax', 'SWCr',
+                   'SWCrmax', 'MeasKs']
             Year    - 4-digit year (yyyy)
             DOY     - Day of year  (ddd)
             Zr      - Simulated root depth (m), FAO-56 page 279
@@ -46,18 +48,15 @@ class SoilWater:
 
     Methods
     -------
-    savefile(swc_path='tools_pyfao56.vswc',swd_path=
-             'tools_pyfao56.vswd', rzsw_path='tools_pyfao56.rzsw')
+    savefile(swc_path='tools_pyfao56.vswc',
+             rzsw_path='tools_pyfao56.rzsw')
         Save SoilWater attribute(s) to file(s)
-    loadfile(swc_path='tools_pyfao56.vswc',swd_path=
-             'tools_pyfao56.vswd', rzsw_path='tools_pyfao56.rzsw')
+    loadfile(swc_path='tools_pyfao56.vswc',
+             rzsw_path='tools_pyfao56.rzsw')
         Load SoilWater attribute(s) from file(s)
     customload()
         Override this function to customize loading measured
         volumetric soil water content data.
-    compute_swd_from_swc()
-        Compute measured soil water deficit (for each soil layer)
-        from swcdata class atrribute. Populates swddata class attribute.
     compute_root_zone_sw()
         Compute measured soil water deficit (mm) and measured volumetric
         soil water content (mm) in the active root zone and in the
@@ -66,79 +65,50 @@ class SoilWater:
         object. Populates rzdata class attribute.
     """
 
-    def __init__(self, mdl=None, *args):
+    def __init__(self, mdl=None, swc_path=None, rzsw_path=None):
         """
         Initialize the SoilWater class object.
 
         Parameters
         ----------
-        mdl   : pyfao56 Model class object, optional
+        mdl : pyfao56 Model class object, optional
             pyfao56 Model class that can be used for calculating soil
             water deficit and/or root zone soil water values.
-            Default is None.
-        *args : str
-            A variable number of file paths that the user wants to load.
-            The supported file extensions are 'vswc', 'vswd', and 'rzsw'.
-
-        Raises
-        ------
-        ValueError
-            If the file does not have an accepted file extension.
+            (default = None)
+        swc_path : str, optional
+            Any valid filepath  for loading a soil water content file.
+            (default = None)
+        rzsw_path : str, optional
+            Any valid filepath for loading a root zone soil water file.
+            (default = None)
 
         Notes
         -----
-        If only 'vswc' file is passed, then SWD and SWrz are computed.
-        If only 'vswc' and 'vswd' files are passed, then the root zone
-        soil water values are calculated.
-
         If the user does not load from a file, then they can use the
-        customload method to populate the swcdata attribute.
+        customload method to populate the SoilWater class attributes.
         """
-        # Initialize two main class attributes as None types:
-        self.swcdata = None
-        self.swddata = None
-        self.rzdata  = None
         # Initialize rzdata column names
-        self.rz_cnames = ['Year', 'DOY', 'Zr', 'SWDr',
-                          'SWDrmax', 'SWCr', 'SWCrmax', 'MeasKs']
-
-        # Create list of acceptable file extensions
-        accepted_extensions = ['vswc', 'vswd', 'rzsw']
-        # Set class model object (if one is passed at instantiation)
+        self.rz_cnames = ['Year', 'DOY', 'Zr', 'SWDr', 'SWDrmax',
+                          'SWCr', 'SWCrmax', 'MeasKs']
+        # Set Parameters object (if one is passed at instantiation)
         if mdl is not None:
             self.mdl = mdl
-        # Load files to the class attributes
-        if args:
-            for filepath in args:
-                deconstructed_filepath = filepath.rsplit('.', 1)
-                extension = deconstructed_filepath[-1].lower()
-                if extension not in accepted_extensions:
-                    raise ValueError(f'{filepath} does not have an '
-                                     f'accepted file extension.')
-                elif extension == 'vswc':
-                    self.loadfile(swc_path=filepath)
-                elif extension == 'vswd':
-                    self.loadfile(swd_path=filepath)
-                elif extension == 'rzsw':
-                    self.loadfile(rzsw_path=filepath)
-            # If only a vswc file is given, then compute SWD and SWrz
-            if self.swddata is None and self.rzdata is None:
-                self.compute_swd_from_swc()
-                self.compute_root_zone_sw()
-            # If only vswc and vswd files are given, then compute SWrz
-            elif self.rzdata is None:
-                self.compute_root_zone_sw()
-        # If not loading from file, then use customload to populate swc
+        # Load the SWC class attribute
+        if swc_path is not None:
+            self.loadfile(swc_path=swc_path)
         else:
             self.swcdata = pd.DataFrame()
-            self.swddata = pd.DataFrame()
-            self.rzdata  = pd.DataFrame(columns=self.rz_cnames)
+        # Load the RZSW class attribute
+        if rzsw_path is not None:
+            self.loadfile(rzsw_path=rzsw_path)
+        else:
+            self.rzdata = pd.DataFrame(columns=self.rz_cnames)
 
     def __str__(self, method='all'):
         """Represent the SoilWater class as a string"""
 
         method = method.lower()
-        accepted_methods = ['all', 'vswc', 'vswd', 'rzsw']
+        accepted_methods = ['all', 'vswc', 'rzsw']
         title = 'pyfao56: FAO-56 Evapotranspiration in Python'
         ast = '*' * 72
         if method not in accepted_methods:
@@ -147,21 +117,10 @@ class SoilWater:
                              f'{accepted_methods}')
         elif method == 'all':
             swc = self.__str__(method='vswc')
-            swd = self.__str__(method='vswd')
             rzsw = self.__str__(method='rzsw')
-            if (swc is not None)&(swd is not None)&(rzsw is not None):
-                s = swc + f'\n{ast}\n' + swd + f'\n{ast}\n' + rzsw
-            elif (swc is not None)&(swd is not None)&(rzsw is None):
-                s = swc + f'\n{ast}\n' + swd
-            elif (swc is not None)&(swd is None)&(rzsw is None):
-                s = swc
-            elif (swc is None) & (swd is None) & (rzsw is None):
-                s = 'Pyfao56 Tools SoilWater class is empty.'
+            s = swc + f'\n{ast}\n' + rzsw
             return s
         elif method == 'vswc':
-            if self.swcdata is None:
-                print('swcdata Class attribute is empty.')
-                return
             fmts = {'__index__': '{:5d}'.format}
             for date_col in list(self.swcdata):
                 fmts[date_col] = '{:8.3f}'.format
@@ -178,30 +137,7 @@ class SoilWater:
                                         na_rep='    NaN',
                                         formatters=fmts)
             return s
-        elif method == 'vswd':
-            if self.swddata is None:
-                print('SoilWater swddata class attribute is empty.\n')
-                return
-            fmts = {'__index__': '{:5d}'.format}
-            for date_col in list(self.swddata):
-                fmts[date_col] = '{:8.3f}'.format
-            s = ('{:s}\n'
-                 '{:s}\n'
-                 'Tools: Measured Soil Water Deficit (cm^3/cm^3) Data '
-                 'by Layer\n'
-                 '{:s}\n'
-                 'Depth').format(ast, title, ast)
-            for cname in list(self.swddata):
-                s += '{:>9s}'.format(cname)
-            s += '\n'
-            s += self.swddata.to_string(header=False,
-                                        na_rep='    NaN',
-                                        formatters=fmts)
-            return s
         elif method == 'rzsw':
-            if self.rzdata is None:
-                print('SoilWater rzdata class attribute is empty.\n')
-                return
             fmts = {'Year': '{:4s}'.format, 'DOY': '{:3s}'.format,
                     'Zr': '{:5.3f}'.format, 'SWDr': '{:7.3f}'.format,
                     'SWDrmax': '{:7.3f}'.format,
@@ -213,21 +149,20 @@ class SoilWater:
                  'Tools: Simulated Root Zone (m) & Measured Soil '
                  'Water (mm) Data\n'
                  '{:s}\n'
-                 'Year DOY    Zr    SWDr SWDrmax    SWCr SWCrmax MeasKs\n'
+                 'Year DOY    Zr    SWDr SWDrmax    SWCr SWCrmax '
+                 'MeasKs\n'
                  ).format(ast, title, ast)
             s += self.rzdata.to_string(header=False,
                                        index=False,
                                        formatters=fmts)
             return s
 
-    def savefile(self, swc_path=None, swd_path=None, rzsw_path=None):
+    def savefile(self, swc_path=None, rzsw_path=None):
         """Save measured soil water data to a file.
 
         Parameters
         ----------
         swc_path  : str, optional
-            Any valid filepath string (default = None)
-        swd_path  : str, optional
             Any valid filepath string (default = None)
         rzsw_path : str, optional
             Any valid filepath string (default = None)
@@ -246,15 +181,6 @@ class SoilWater:
             else:
                 f.write(self.__str__(method='vswc'))
                 f.close()
-        if swd_path is not None:
-            try:
-                f = open(swd_path, 'w')
-            except FileNotFoundError:
-                print('The filepath for soil water deficit data is not '
-                      'found.')
-            else:
-                f.write(self.__str__(method='vswd'))
-                f.close()
         if rzsw_path is not None:
             try:
                 f = open(rzsw_path, 'w')
@@ -264,17 +190,15 @@ class SoilWater:
             else:
                 f.write(self.__str__(method='rzsw'))
                 f.close()
-        if (swc_path is None)&(swd_path is None)&(rzsw_path is None):
+        if (swc_path is None) & (rzsw_path is None):
             print('Please specify a filepath for data to be saved.')
 
-    def loadfile(self, swc_path=None, swd_path=None, rzsw_path=None):
-        """Load pyfao56 soil profile data from a file.
+    def loadfile(self, swc_path=None, rzsw_path=None):
+        """Load measured soil water data from a file.
 
         Parameters
         ----------
         swc_path  : str, optional
-            Any valid filepath string (default = None)
-        swd_path  : str, optional
             Any valid filepath string (default = None)
         rzsw_path : str, optional
             Any valid filepath string (default = None)
@@ -302,24 +226,6 @@ class SoilWater:
                     for i in list(range(1, len(cols) + 1)):
                         data.append(float(line[i]))
                     self.swcdata.loc[depth] = data
-        if swd_path is not None:
-            try:
-                f = open(swd_path, 'r')
-            except FileNotFoundError:
-                print('The filepath for soil water deficit data is not '
-                      'found.')
-            else:
-                lines = f.readlines()
-                f.close()
-                cols = lines[4].strip().split()[1:]
-                self.swddata = pd.DataFrame(columns=cols)
-                for line in lines[5:]:
-                    line = line.strip().split()
-                    depth = int(line[0])
-                    data = list()
-                    for i in list(range(1, len(cols) + 1)):
-                        data.append(float(line[i]))
-                    self.swddata.loc[depth] = data
         if rzsw_path is not None:
             try:
                 f = open(rzsw_path, 'r')
@@ -329,19 +235,17 @@ class SoilWater:
             else:
                 lines = f.readlines()
                 f.close()
-                cnames = ['Zr', 'SWDr', 'SWDrmax', 'SWCr',
-                          'SWCrmax', 'MeasKs']
-                self.rzdata = pd.DataFrame(columns=cnames)
+                self.rzdata = pd.DataFrame(columns=self.rz_cnames)
                 for line in lines[5:]:
                     line = line.strip().split()
                     year = line[0]
                     doy = line[1]
                     key = '{:04d}-{:03d}'.format(int(year), int(doy))
-                    data = list()
+                    data = [year, doy]
                     for i in list(range(2, 8)):
                         data.append(float(line[i]))
                     self.rzdata.loc[key] = data
-        if (swc_path is None)&(swd_path is None)&(rzsw_path is None):
+        if (swc_path is None) & (rzsw_path is None):
             print('Please specify a filepath for data to be loaded.')
 
     def customload(self):
@@ -351,13 +255,16 @@ class SoilWater:
 
         pass
 
-    def compute_swd_from_swc(self):
-        """Compute measured soil water deficit (for each soil layer)
-        from swcdata class atrribute. Populates swddata class attribute.
-        """
+    def compute_root_zone_sw(self):
+        """Compute measured soil water deficit (mm) and measured
+        volumetric soil water content (mm) in the active root zone and
+        in the maximum root zone, based on pyfao56 Model root depth
+        estimates. Also computes Ks based on measured SWD and pyfao56
+        Model class object. Populates rzdata class attribute."""
+
+        # ****************** Computing SWD by Layer ********************
         # Making a base dataframe out of swcdata
         swddata = self.swcdata.copy()
-        # Checking if soil class attribute exists
         try:
             sol = self.mdl.sol
         except AttributeError:
@@ -375,32 +282,17 @@ class SoilWater:
             swddata['thetaFC'] = sol['thetaFC'].copy()
         # Creating a list of the column names in the swddata dataframe
         cnames = list(swddata.columns)
+        swd_dates = []
         # Looping through column names; calculating SWD on date columns
         for cname in cnames:
             if cname != 'thetaFC':
+                # Create list of measurement dates
+                swd_dates += [cname]
                 # "Clip" sets negative SWD values to zero
                 swddata[cname] = (swddata['thetaFC'] -
                                        swddata[cname]).clip(lower=0)
-        # Dropping the Field Capacity info from the dataframe (K.I.S.)
-        swddata.drop('thetaFC', axis=1, inplace=True)
-        # Write swddata to class attribute
-        self.swddata = swddata
 
-    def compute_root_zone_sw(self):
-        """Compute measured soil water deficit (mm) and measured
-        volumetric soil water content (mm) in the active root zone and
-        in the maximum root zone, based on pyfao56 Model root depth
-        estimates. Also computes Ks based on measured SWD and pyfao56
-        Model class object. Populates rzdata class attribute."""
-
-        # ********************* Setting things up **********************
-        # Get lists of measurement dates SWD
-        try:
-            swd_dates = list(self.swddata.columns)
-        except AttributeError:
-            print('To compute root zone soil water values, please first'
-                  ' populate the swddata class attribute. \n')
-            return
+        # ******************** Setting things up ***********************
         # Get lists of years and days of measurements from dates list
         years = []
         days = []
@@ -430,7 +322,7 @@ class SoilWater:
         SWCr    = {}
         SWCrmax = {}
         for mykey in swd_dates:
-            lyr_dpths = list(self.swddata[mykey].index)
+            lyr_dpths = list(swddata[mykey].index)
             # Finding root depth(10^-5 m) on measurement days
             try:
                 Zr = rzdata.loc[mykey, 'Zr'] * 100000  #10^-5 meters
@@ -450,10 +342,10 @@ class SoilWater:
                        if inc <= dpth * 1000][0]  #10^-5 meters
                 # Compute SWD(mm) & SWC(mm) in active root depth for day
                 if inc <= Zr:
-                    Dr   += self.swddata.loc[lyr, mykey] / 100  #mm
+                    Dr   += swddata.loc[lyr, mykey] / 100  #mm
                     H2Or += self.swcdata.loc[lyr, mykey] / 100  #mm
                 # Compute measured SWD(mm) & SWC(mm) in max root depth
-                Drmax   += self.swddata.loc[lyr, mykey] / 100  #mm
+                Drmax   += swddata.loc[lyr, mykey] / 100  #mm
                 H2Ormax += self.swcdata.loc[lyr, mykey] / 100  #mm
             # Add SWD values to dictionaries with measurement day as key
             SWDr[mykey] = Dr
@@ -480,4 +372,3 @@ class SoilWater:
 
         # Populate rzdata class attribute
         self.rzdata = rzdata
-

--- a/tests/test6/SoilWaterTest.py
+++ b/tests/test6/SoilWaterTest.py
@@ -54,75 +54,70 @@ def run():
     mdl_sol.savefile(os.path.join(module_dir,'E12FF2022_Soil.out'))
 
     print('Testing SoilWater class initialization...\n')
-    # Use soil water content file to initialize SoilWater class
+    # Initialize with a model only
+    print('Testing initialization with just a model...\n')
+    wtr = SoilWater(mdl=mdl)
+    print(wtr)
+
+    # Test the loadfile function
     swc_file = os.path.join(module_dir, 'E12FF2022.vswc')
+    rzsw_file = os.path.join(module_dir, 'E12FF2022.rzsw')
+    # Testing using the swc method
+    print('\nLoading soil water content file...\n')
+    wtr.loadfile(swc_path=swc_file)
+    print(wtr, '\n')
+    # Testing using the rzsw method
+    print('Loading soil water root zone file...\n')
+    wtr.loadfile(rzsw_path=rzsw_file)
+    print(wtr, '\n')
+
     # Initialize without a model
-    print('Testing initialization with smc file but no model...\n')
-    wtr0 = SoilWater(None, swc_file)
+    print('Testing initialization with swc file but no model...\n')
+    wtr0 = SoilWater(swc_path=swc_file)
     print(wtr0, '\n')
+
     # Initialize with default model
-    print('Testing initialization with smc file & default model...\n')
-    wtr1 = SoilWater(mdl, swc_file)
+    print('Testing initialization with swc file & default model...\n')
+    wtr1 = SoilWater(mdl=mdl, swc_path=swc_file)
+    wtr1.compute_root_zone_sw()
     print(wtr1, '\n')
     # Initialize with stratified soil model
-    print('Testing initialization with smc file & stratified soil '
+    print('Testing initialization with swc file & stratified soil '
           'model...\n')
-    wtr2 = SoilWater(mdl_sol, swc_file)
+    wtr2 = SoilWater(mdl=mdl_sol, swc_path=swc_file)
+    wtr2.compute_root_zone_sw()
     print(wtr2, '\n')
-    # Initialize empty class
-    print('Testing empty class initialization...\n')
-    wtr3 = SoilWater()
-    print(wtr3, '\n')
 
     # Test the savefile function
     swc_file2 = os.path.join(module_dir, 'E12FF2022_NEW.vswc')
-    swd_file  = os.path.join(module_dir, 'E12FF2022.vswd')
-    rzsw_file = os.path.join(module_dir, 'E12FF2022.rzsw')
+    rzsw_file = os.path.join(module_dir, 'E12FF2022_NEW.rzsw')
     print('Testing savefile function...\n')
-    wtr2.savefile(swc_path=swc_file2, swd_path=swd_file,
-                  rzsw_path=rzsw_file)
-    if os.path.exists(swc_file2):
-        print(f"The {swc_file2} was successfully saved.\n")
+    wtr2.savefile(swc_path=swc_file2, rzsw_path=rzsw_file)
+    if os.path.exists(swc_file2) & os.path.exists(rzsw_file):
+        print(f"{swc_file2} and {rzsw_file} were successfully saved.\n")
     else:
-        print(f"The {swc_file2} was not saved. \n")
+        print(f"{swc_file2} and {rzsw_file} were NOT SAVED. \n")
     print('Testing savefile function error message...\n')
     wtr2.savefile()
 
-    # Test the loadfile function
-    # Testing using the swc method
-    print('Loading soil water content file...\n')
+    # Initialize empty class
+    print('Testing empty class initialization...\n')
+    wtr3 = SoilWater()
+    wtr3.compute_root_zone_sw()
+    print(wtr3, '\n')
+    # Testing compute root zone method
+    print('Computing root zone soil water from swc file...\n')
     wtr3.loadfile(swc_path=swc_file2)
-    print(wtr3, '\n')
-    # Testing using the swd method
-    print('Loading soil water deficit file...\n')
-    wtr3 = SoilWater()
-    wtr3.loadfile(swd_path=swd_file)
-    print(wtr3, '\n')
-    # Testing using the swrz method
-    print('Loading soil water root zone file...\n')
-    wtr3 = SoilWater()
-    wtr3.loadfile(rzsw_path=rzsw_file)
-    print(wtr3, '\n')
-    # Testing using all three methods
-    print('Loading soil water data...\n')
-    wtr3 = SoilWater()
-    wtr3.loadfile(swc_path=swc_file2, swd_path=swd_file,
-                  rzsw_path=rzsw_file)
+    wtr3.compute_root_zone_sw()
+    # Previous line results in an error message due to lack of a model
+    print('Loading model & retrying now')
+    wtr3.mdl = mdl_sol
+    wtr3.compute_root_zone_sw()
     print(wtr3, '\n')
 
     # I have an example customload function, but it depends on openpyxl,
     # and I don't want to have to make that a pyfao56 dependency. So I
     # am skipping testing the customload function
-
-    # Testing compute functions
-    print('Testing the compute_swd_from_swc function...\n')
-    wtr = SoilWater(mdl=mdl_sol)
-    wtr.loadfile(swc_file2)
-    wtr.compute_swd_from_swc()
-    print(wtr, '\n')
-    print('Testing the compute_root_zone_sw function...\n')
-    wtr.compute_root_zone_sw()
-    print(wtr, '\n')
 
 if __name__ == '__main__':
     run()


### PR DESCRIPTION
I simplified the class by removing the swddata class attribute. As a result, I was also able to remove the .vswd I/O file methods. The class is overall simpler as a result. 

While testing, I also discovered that the rzswd file was not being loaded correctly. I fixed that bug so that it now works as intended.

Moving forward, I will be working on making this class dependent on par and sol rather than on mdl. That is what we discussed last week to avoid circularity issues. I realized that mdl would have to be passed back to SoilWater at some point if a user wants to calculate measured Ks, so maybe that justifies moving that calculation to the model? I am not sure. 