### PR TITLE
Optional Irrigation Class

### DIFF
--- a/src/pyfao56/irrigation.py
+++ b/src/pyfao56/irrigation.py
@@ -64,6 +64,11 @@ class Irrigation:
            '{:s}\n'
            'Year-DOY  Depth     fw\n'
           ).format(ast,ast)
+
+        if self.idata.empty:
+            empty_row = [-99.99] * len(self.idata.columns)
+            self.idata.loc["-999-999"] = empty_row
+
         s += self.idata.to_string(header=False)
         return s
 

--- a/src/pyfao56/model.py
+++ b/src/pyfao56/model.py
@@ -42,8 +42,9 @@ class Model:
         Provides the parameter data for simulations
     wth : pyfao56 Weather class
         Provides the weather data for simulations
-    irr : pyfao56 Irrigation class
+    irr : pyfao56 Irrigation object, optional
         Provides the irrigation data for simulations
+        (default = None)
     sol : pyfao56 SoilProfile class, optional
         Provides data for modeling with stratified soil layers
         (default = None)
@@ -117,7 +118,7 @@ class Model:
         Conduct the FAO-56 calculations from startDate to endDate
     """
 
-    def __init__(self, start, end, par, wth, irr, sol=None, upd=None,
+    def __init__(self, start, end, par, wth, irr=None, sol=None, upd=None,
                  cons_p=False):
         """Initialize the Model class attributes.
 
@@ -131,8 +132,9 @@ class Model:
             Provides the parameter data for simulations
         wth : pyfao56 Weather object
             Provides the weather data for simulations
-        irr : pyfao56 Irrigation object
+        irr : pyfao56 Irrigation object, optional
             Provides the irrigation data for simulations
+            (default = None)
         sol : pyfao56 SoilProfile object, optional
             Provides data for modeling with stratified soil layers
             (default = None)
@@ -332,9 +334,12 @@ class Model:
                 io.rhmin = ea/emax*100.
             if math.isnan(io.rhmin):
                 io.rhmin = 45.
-            if mykey in self.irr.idata.index:
-                io.idep = self.irr.idata.loc[mykey,'Depth']
-                io.fw = self.irr.idata.loc[mykey,'fw']
+            if self.irr is not None:
+                if mykey in self.irr.idata.index:
+                    io.idep = self.irr.idata.loc[mykey,'Depth']
+                    io.fw = self.irr.idata.loc[mykey,'fw']
+                else:
+                    io.idep = 0.0
             else:
                 io.idep = 0.0
 


### PR DESCRIPTION
## The What:

Made changes to model.py and irrigation.py to make it possible for users to run the model without irrigation data. 

The changes to model.py make irrigation class objects into optional inputs to the model. 

Prior to the changes to irrigation.py, empty irrigation class files looked like this:
![Empty_Irrigation_PreFix](https://github.com/kthorp/pyfao56/assets/108552171/0c23ca59-5c26-494e-8a73-4dd30c437d01)
The above file would break the model if a user attempted to load it. 

Now, empty irrigation class files look like this:
![Empy_Irrigation_PostFix](https://github.com/kthorp/pyfao56/assets/108552171/32bac6cc-e64a-4b32-9b90-40720f4e3186)

The new empty file can be loaded to an irrigation class, which can then be handed to a model class without any (known) unexpected or adverse behavior. 

## The Why:

As a result of these changes, users can now run the model without an irrigation class object, or they can run the model with an empty irrigation class object (loaded from the empty file). Hopefully this makes the package more useful for dry-land users and in-season users.  