### PR TITLE
Fixed Update Class NaN String

### DIFF
--- a/src/pyfao56/update.py
+++ b/src/pyfao56/update.py
@@ -68,7 +68,12 @@ class Update:
            '{:s}\n'
            'Year-DOY    Kcb      h     fc\n'
           ).format(ast,ast)
-        s += self.udata.to_string(header=False, na_rep='   NaN')
+
+        if self.udata.empty:
+            empty_row = ['   NaN'] * len(self.udata.columns)
+            self.udata.loc["-999-999"] = empty_row
+
+        s += self.udata.to_string(header=False, na_rep='  NaN')
         return s
 
     def savefile(self,filepath='pyfao56.upd'):


### PR DESCRIPTION
## The What:

Fixed the typesetting error with the Update class NaN rep string. Also added empty dataframe safeguard for users who make a file out of an empty update class. I just reused the code that was used for the same purpose in the irrigation class.

Below are screenshots of test Update class files before and after these changes. 

### **Before changes:**
- Single column of data:
![UpdateFile_PreFix](https://github.com/kthorp/pyfao56/assets/108552171/c6041fc4-cf89-44d7-a1bd-327fed3e4180)

- Three columns of data, but with NaNs throughout:
![UpdateFile_PreFixAllRows](https://github.com/kthorp/pyfao56/assets/108552171/a9dae43a-1cec-4a8c-89c5-a816a7ddadb0)

- Empty dataframe saved file:
![EmptyUpdateFile_PreFix](https://github.com/kthorp/pyfao56/assets/108552171/cdde5f52-c8fe-4682-8dd2-4a7fe75cbf0d)


### **After changes:**
- Single column of data:
![UpdateFile_PostFix](https://github.com/kthorp/pyfao56/assets/108552171/087082e1-83a8-4ebb-8349-9aa8403147e1)

- Three columns of data, but with NaNs throughout:
![UpdateFile_PostFixAllRows](https://github.com/kthorp/pyfao56/assets/108552171/eed5eec3-4ef3-4c1f-a7e1-90ae1b282b7b)

- Empty dataframe saved file:
![EmptyUpdateFile_PostFix](https://github.com/kthorp/pyfao56/assets/108552171/5e77387a-eb56-4d7c-ad02-6d95d93ec7fb)

## The Why:

To get rid of the (extremely minor) typesetting error in .upd files and to make it easier for users to use .upd files mid-season. 