### PR TITLE
Adjusted Default hini Value

### DIFF
--- a/src/pyfao56/parameters.py
+++ b/src/pyfao56/parameters.py
@@ -62,7 +62,7 @@ class Parameters:
     """
 
     def __init__(self, Kcbini=0.15, Kcbmid=1.10, Kcbend=0.50, Lini=25,
-                 Ldev=50, Lmid=50, Lend=25, hini=0.05, hmax=1.20,
+                 Ldev=50, Lmid=50, Lend=25, hini=0.013, hmax=1.20,
                  thetaFC=0.250, thetaWP=0.100, theta0=0.100, Zrini=0.20,
                  Zrmax=1.40, pbase=0.50, Ze=0.10, REW=8.0):
         """Initialize the Parameters class attributes.
@@ -81,7 +81,7 @@ class Parameters:
         Ldev    : int  , default = 50
         Lmid    : int  , default = 50
         Lend    : int  , default = 25
-        hini    : float, default = 0.05
+        hini    : float, default = 0.013
         hmax    : float, default = 1.20
         thetaFC : float, default = 0.250
         thetaWP : float, default = 0.100


### PR DESCRIPTION
I searched FAO-56 for more insight on what initial height should usually be assumed to be. I couldn't find anything.

Kelly mentioned that the 0.05m value is probably a remnant of the Maricopa spreadsheets.

I changed the default value to 0.013m, which is roughly half an inch. I think that assumption is a little more realistic for most initial crop heights, but I also don't think this parameter matters much at all.